### PR TITLE
Make vignette easier to access and add title

### DIFF
--- a/vignettes/lcvplants.Rmd
+++ b/vignettes/lcvplants.Rmd
@@ -1,4 +1,5 @@
 ---
+title: "Taxonomic name resolution with LCVP and lcvplants"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Taxonomic name resolution using the Leipzig Catalogue of Vascular Plants and `lcvplants`}


### PR DESCRIPTION
For the moment when browser the `lcvplants` website this is what we can see:
![Capture d’écran 2021-01-19 à 19 06 22](https://user-images.githubusercontent.com/5593751/105075024-7c751780-5a89-11eb-8b76-ae32ab74063e.png)
This is due to the fact that no `title` field was defined in the vignette YAML preamble. I propose doing so in this branch.

Another suggestion would be to rename the vignette to `lcvplants.Rmd` so that `pkgdown` can [pick it up](https://pkgdown.r-lib.org/reference/build_articles.html?q=get%20started#get-started) and show the vignette as "Get started" in the navbar on the website:

> Get started
> 
> Note that a vignette with the same name as the package (e.g., vignettes/pkgdown.Rmd or vignettes/articles/pkgdown.Rmd) automatically becomes a top-level "Get started" link, and will not appear in the articles drop-down.
> 
> (If your package name includes a ., e.g. pack.down, use a - in the vignette name, e.g. pack-down.Rmd.)

and it displays as follow:
![Capture d’écran 2021-01-19 à 19 11 05](https://user-images.githubusercontent.com/5593751/105075504-1f2d9600-5a8a-11eb-886a-5654351ad67c.png)


